### PR TITLE
RT bug fixes

### DIFF
--- a/pvder/DER_check_and_initialize.py
+++ b/pvder/DER_check_and_initialize.py
@@ -57,9 +57,9 @@ class PVDER_SetupUtilities(BaseValues):
 					self.DER_config[RT_component] = DER_arguments[RT_component]
 				elif RT_component in DER_config:
 					self.DER_config[RT_component] = DER_config[RT_component]
-					LogUtil.logger.info('{}:Updating {} from DER config {} with settings:{}.'.format(self.name,RT_component,DER_id,DER_config[RT_component]))
+					LogUtil.logger.debug('{}:Updating {} from DER config {} with settings:{}.'.format(self.name,RT_component,DER_id,DER_config[RT_component]))
 				elif RT_component in DER_parent_config: #Check if RT setting exists in parent config file
-					LogUtil.logger.info('{}:Updating {} from parent DER config {} with settings {}.'.format(self.name,RT_component,DER_parent_id,DER_parent_config[RT_component])) 
+					LogUtil.logger.debug('{}:Updating {} from parent DER config {} with settings {}.'.format(self.name,RT_component,DER_parent_id,DER_parent_config[RT_component])) 
 					self.DER_config[RT_component] = DER_parent_config[RT_component]
 				else:
 					if RT_component in list(templates.VRT_config_template.keys()):
@@ -68,8 +68,6 @@ class PVDER_SetupUtilities(BaseValues):
 						default_RT = templates.FRT_config_template[RT_component]
 					LogUtil.logger.debug('{}:Updating {} from template with  settings:{}.'.format(self.name,RT_component,default_RT))
 					self.DER_config[RT_component] = default_RT
-
-					#raise ValueError("{} not found!".format(RT_component))
 	
 			self.basic_specs = {DER_id:self.DER_config['basic_specs']}
 			self.module_parameters = {DER_id:self.DER_config['module_parameters']}

--- a/pvder/DER_check_and_initialize.py
+++ b/pvder/DER_check_and_initialize.py
@@ -51,7 +51,7 @@ class PVDER_SetupUtilities(BaseValues):
 					for DER_parameter in self.DER_design_template[DER_component]:
 						_ = self.update_DER_parameter(DER_config,DER_parent_config,DER_arguments,DER_id,DER_parent_id,DER_component,DER_parameter)
 	
-			for RT_component in list(templates.VRT_config_template.keys()) + list(templates.FRT_config_template.keys
+			for RT_component in list(templates.VRT_config_template.keys()) + list(templates.FRT_config_template.keys()):
 				if RT_component in DER_arguments:
 					LogUtil.logger.debug('{}:Updating {} from DER arguments with settings:{}.'.format(self.name,RT_component,DER_arguments[RT_component]))
 					self.DER_config[RT_component] = DER_arguments[RT_component]
@@ -65,7 +65,7 @@ class PVDER_SetupUtilities(BaseValues):
 					if RT_component in list(templates.VRT_config_template.keys()):
 						default_RT = templates.VRT_config_template[RT_component]['config']
 					if RT_component in list(templates.FRT_config_template.keys()):
-						self.DER_config[RT_component]default_RT = templates.FRT_config_template[RT_component]['config']
+						default_RT = templates.FRT_config_template[RT_component]['config']
 					LogUtil.logger.debug('{}:Updating {} from template with  settings:{}.'.format(self.name,RT_component,default_RT))
 					self.DER_config[RT_component] = default_RT
 

--- a/pvder/DER_check_and_initialize.py
+++ b/pvder/DER_check_and_initialize.py
@@ -45,15 +45,31 @@ class PVDER_SetupUtilities(BaseValues):
 			#parameters_from_default = {}
 	
 			for DER_component in self.DER_design_template:
-				if DER_component in DER_arguments['derConfig']: 
-					self.DER_config[DER_component] = DER_arguments['derConfig'][DER_component]
+				if DER_component in DER_arguments: 
+					self.DER_config[DER_component] = DER_arguments[DER_component]
 				else:
 					for DER_parameter in self.DER_design_template[DER_component]:
 						_ = self.update_DER_parameter(DER_config,DER_parent_config,DER_arguments,DER_id,DER_parent_id,DER_component,DER_parameter)
 	
-			for RT_component in list(templates.VRT_config_template.keys()) + list(templates.FRT_config_template.keys()):
-				if RT_component in DER_config:
+			for RT_component in list(templates.VRT_config_template.keys()) + list(templates.FRT_config_template.keys
+				if RT_component in DER_arguments:
+					LogUtil.logger.debug('{}:Updating {} from DER arguments with settings:{}.'.format(self.name,RT_component,DER_arguments[RT_component]))
+					self.DER_config[RT_component] = DER_arguments[RT_component]
+				elif RT_component in DER_config:
 					self.DER_config[RT_component] = DER_config[RT_component]
+					LogUtil.logger.info('{}:Updating {} from DER config {} with settings:{}.'.format(self.name,RT_component,DER_id,DER_config[RT_component]))
+				elif RT_component in DER_parent_config: #Check if RT setting exists in parent config file
+					LogUtil.logger.info('{}:Updating {} from parent DER config {} with settings {}.'.format(self.name,RT_component,DER_parent_id,DER_parent_config[RT_component])) 
+					self.DER_config[RT_component] = DER_parent_config[RT_component]
+				else:
+					if RT_component in list(templates.VRT_config_template.keys()):
+						default_RT = templates.VRT_config_template[RT_component]['config']
+					if RT_component in list(templates.FRT_config_template.keys()):
+						self.DER_config[RT_component]default_RT = templates.FRT_config_template[RT_component]['config']
+					LogUtil.logger.debug('{}:Updating {} from template with  settings:{}.'.format(self.name,RT_component,default_RT))
+					self.DER_config[RT_component] = default_RT
+
+					#raise ValueError("{} not found!".format(RT_component))
 	
 			self.basic_specs = {DER_id:self.DER_config['basic_specs']}
 			self.module_parameters = {DER_id:self.DER_config['module_parameters']}
@@ -80,7 +96,7 @@ class PVDER_SetupUtilities(BaseValues):
 				else:
 					raise ValueError('Found {} to have type {} - expected type:{}!'.format(DER_parameter,type(DER_arguments[DER_parameter]),DER_parameter_type))
 		
-			elif DER_parameter in DER_config[DER_component]: #Check if parameter exists in config file			
+			elif DER_parameter in DER_config[DER_component]: #Check if parameter exists in config file
 				if isinstance(DER_config[DER_component][DER_parameter],DER_parameter_type):
 					LogUtil.logger.debug('{}:Parameter {} in {} for ID:{} - updating from DER config {} with value {}.'.format(self.name,DER_parameter,DER_component,DER_id,DER_id,DER_config[DER_component][DER_parameter])) 
 					self.DER_config[DER_component].update({DER_parameter:DER_config[DER_component][DER_parameter]})
@@ -89,7 +105,7 @@ class PVDER_SetupUtilities(BaseValues):
 				else:
 					raise ValueError('Found {} to have type {} - expected type:{}!'.format(DER_parameter,type(DER_config[DER_component][DER_parameter]),DER_parameter_type))
 		
-			elif DER_parameter in DER_parent_config[DER_component]: #Check if parameter exists in parent config file			
+			elif DER_parameter in DER_parent_config[DER_component]: #Check if parameter exists in parent config file
 				if isinstance(DER_parent_config[DER_component][DER_parameter],DER_parameter_type):
 					LogUtil.logger.debug('{}:Parameter {} in {} for ID:{} - updating from parent DER config {} with value {}.'.format(self.name,DER_parameter,DER_component,DER_id,DER_parent_id,DER_parent_config[DER_component][DER_parameter])) 
 					self.DER_config[DER_component].update({DER_parameter:DER_parent_config[DER_component][DER_parameter]})

--- a/pvder/DER_check_and_initialize.py
+++ b/pvder/DER_check_and_initialize.py
@@ -63,9 +63,9 @@ class PVDER_SetupUtilities(BaseValues):
 					self.DER_config[RT_component] = DER_parent_config[RT_component]
 				else:
 					if RT_component in list(templates.VRT_config_template.keys()):
-						default_RT = templates.VRT_config_template[RT_component]['config']
+						default_RT = templates.VRT_config_template[RT_component]
 					if RT_component in list(templates.FRT_config_template.keys()):
-						default_RT = templates.FRT_config_template[RT_component]['config']
+						default_RT = templates.FRT_config_template[RT_component]
 					LogUtil.logger.debug('{}:Updating {} from template with  settings:{}.'.format(self.name,RT_component,default_RT))
 					self.DER_config[RT_component] = default_RT
 

--- a/pvder/DER_components.py
+++ b/pvder/DER_components.py
@@ -71,9 +71,9 @@ class SolarPVDER(PVDER_SetupUtilities,PVDER_SmartFeatures,PVDER_ModelUtilities,B
 			self.check_model_type(DER_config,DER_parent_config)
 			self.update_DER_config(DER_config,DER_parent_config,DER_arguments,self.parameter_ID,self.DER_parent_ID)
 			self.check_basic_specs()
-			LogUtil.logger.log(30,'DER config:{}'.format(self.DER_config))
+			
 			self.RT_config = {}
-			self.update_RT_config(self.DER_config,DER_arguments,config_dict) #Checks and updates RT_config if any entries are missing
+			self.update_RT_config(config_dict) #Checks and updates RT_config if any entries are missing
 			self.check_RT_config()
 			
 			return DER_arguments
@@ -197,7 +197,7 @@ class SolarPVDER(PVDER_SetupUtilities,PVDER_SmartFeatures,PVDER_ModelUtilities,B
 			
 			self.initialize_grid_measurements(DER_arguments)
 			self.initialize_DER_model() #DER model parameters
-			self.RT_initialize(DER_arguments) #VRT and FRT settings  
+			self.RT_initialize() #VRT and FRT settings  
 			
 			self.initialize_jacobian()
 			

--- a/pvder/DER_components.py
+++ b/pvder/DER_components.py
@@ -71,9 +71,9 @@ class SolarPVDER(PVDER_SetupUtilities,PVDER_SmartFeatures,PVDER_ModelUtilities,B
 			self.check_model_type(DER_config,DER_parent_config)
 			self.update_DER_config(DER_config,DER_parent_config,DER_arguments,self.parameter_ID,self.DER_parent_ID)
 			self.check_basic_specs()
-			
+			LogUtil.logger.log(30,'DER config:{}'.format(self.DER_config))
 			self.RT_config = {}
-			self.update_RT_config(DER_config,DER_arguments,config_dict) #Checks and updates RT_config if any entries are missing
+			self.update_RT_config(self.DER_config,DER_arguments,config_dict) #Checks and updates RT_config if any entries are missing
 			self.check_RT_config()
 			
 			return DER_arguments

--- a/pvder/DER_features.py
+++ b/pvder/DER_features.py
@@ -222,8 +222,9 @@ class PVDER_SmartFeatures():
 				text_string = '{}:{:.4f}:DER is in disconnect timer zone.'.format(self.name,t)
 				LogUtil.logger.debug(text_string)
 			elif t-self.t_disconnect_start >= self.t_disconnect_delay: #Disconnect DER only after disconnect time delay has elapsed
-				text_string = '{}:{:.4f}:DER will be disconnected.'.format(self.name,t)
-			
+				text_string = '{}:{:.4f}:DER will be disconnected (t_disconnect_timer:{:.4f} s,Vrms measured = {:.4f} V,LVRT Momentary cessation:{},LVRT Trip:{},HVRT Momentary cessation:{},HVRT Trip:{})'.format(self.name,t,
+																					t-self.t_disconnect_start,self.get_Vrms_measured()*self.Vbase,self.LVRT_MOMENTARY_CESSATION,self.LVRT_TRIP,self.HVRT_MOMENTARY_CESSATION,self.HVRT_TRIP)
+				
 				self.print_event(text_string,True) 
 				self.t_disconnect_start = 0.0
 				self.DER_CONNECTED = False

--- a/pvder/DER_features.py
+++ b/pvder/DER_features.py
@@ -581,8 +581,8 @@ class PVDER_SmartFeatures():
 
 	def update_RT_config(self,DER_config,DER_arguments,config_dict):
 		"""Check whether the config file is good."""
-		try:"""
-			for RT in list(templates.VRT_config_template.keys()) +  list(templates.FRT_config_template.keys()):
+		try:
+			"""for RT in list(templates.VRT_config_template.keys()) +  list(templates.FRT_config_template.keys()):
 				if RT in DER_arguments:
 					self.RT_config[RT] = DER_arguments[RT]
 					LogUtil.logger.debug('{}:{} updated with {} from DER arguments.'.format(self.name,RT,DER_arguments[RT]))

--- a/pvder/DER_features.py
+++ b/pvder/DER_features.py
@@ -581,16 +581,16 @@ class PVDER_SmartFeatures():
 
 	def update_RT_config(self,DER_config,DER_arguments,config_dict):
 		"""Check whether the config file is good."""
-		try:
+		try:"""
 			for RT in list(templates.VRT_config_template.keys()) +  list(templates.FRT_config_template.keys()):
-				if RT in DER_arguments['derConfig']:
-					self.RT_config[RT] = DER_arguments['derConfig'][RT]
-					LogUtil.logger.debug('{}:{} updated with {} from derConfig.'.format(self.name,RT,DER_arguments['derConfig'][RT]))
+				if RT in DER_arguments:
+					self.RT_config[RT] = DER_arguments[RT]
+					LogUtil.logger.debug('{}:{} updated with {} from DER arguments.'.format(self.name,RT,DER_arguments[RT]))
 				elif RT in self.DER_config:
-					if 'config_id' in self.DER_config[RT]:
+					if 'config_id' in self.DER_config[RT]: #Check if an RT config id is provided
 						self.RT_config[RT] = config_dict[self.DER_config[RT]['config_id']]['config']
 						LogUtil.logger.debug('{}:{} updated with {} from config id {}.'.format(self.name,RT,config_dict[self.DER_config[RT]['config_id']]['config'],self.DER_config[RT]['config_id']))
-					elif 'config' in self.DER_config[RT]:
+					elif 'config' in self.DER_config[RT]: #Check if an RT settings are provided
 						self.RT_config[RT] = self.DER_config[RT]['config'] 
 						LogUtil.logger.debug('{}:{} updated with {} from DER config file.'.format(self.name,RT,self.DER_config[RT]['config'] ))
 				else:
@@ -600,7 +600,15 @@ class PVDER_SmartFeatures():
 					if RT in list(templates.FRT_config_template.keys()):
 						self.RT_config[RT] = templates.FRT_config_template[RT]['config']
 					LogUtil.logger.debug('{}:{} updated with {} from template.'.format(self.name,RT,self.RT_config[RT]))
-
+			"""
+			for RT in list(templates.VRT_config_template.keys()) +  list(templates.FRT_config_template.keys()):
+				if 'config_id' in self.DER_config[RT]: #Check if an RT config id is provided
+					self.RT_config[RT] = config_dict[self.DER_config[RT]['config_id']]['config']
+					LogUtil.logger.debug('{}:{} updated with {} from config id {}.'.format(self.name,RT,config_dict[self.DER_config[RT]['config_id']]['config'],self.DER_config[RT]['config_id']))
+				elif 'config' in self.DER_config[RT]: #Check if an RT settings are provided
+					self.RT_config[RT] = self.DER_config[RT]['config'] 
+					LogUtil.logger.debug('{}:{} updated with {} from DER config file.'.format(self.name,RT,self.DER_config[RT]['config'] ))
+			
 			for RT in ['LVRT','HVRT']:
 				for RT_level,RT_config in self.RT_config[RT].items():
 					

--- a/pvder/DER_features.py
+++ b/pvder/DER_features.py
@@ -283,7 +283,7 @@ class PVDER_SmartFeatures():
 			LogUtil.exception_handler()
 
 
-	def RT_initialize(self,DER_arguments):
+	def RT_initialize(self):
 		"""Initialize VRT and FRT settings."""	  
 		try:
 			self.VRT_initialize()
@@ -579,7 +579,7 @@ class PVDER_SmartFeatures():
 			LogUtil.exception_handler()
 
 
-	def update_RT_config(self,DER_config,DER_arguments,config_dict):
+	def update_RT_config(self,config_dict):
 		"""Check whether the config file is good."""
 		try:
 			"""for RT in list(templates.VRT_config_template.keys()) +  list(templates.FRT_config_template.keys()):
@@ -602,12 +602,13 @@ class PVDER_SmartFeatures():
 					LogUtil.logger.debug('{}:{} updated with {} from template.'.format(self.name,RT,self.RT_config[RT]))
 			"""
 			for RT in list(templates.VRT_config_template.keys()) +  list(templates.FRT_config_template.keys()):
-				if 'config_id' in self.DER_config[RT]: #Check if an RT config id is provided
-					self.RT_config[RT] = config_dict[self.DER_config[RT]['config_id']]['config']
-					LogUtil.logger.debug('{}:{} updated with {} from config id {}.'.format(self.name,RT,config_dict[self.DER_config[RT]['config_id']]['config'],self.DER_config[RT]['config_id']))
-				elif 'config' in self.DER_config[RT]: #Check if an RT settings are provided
+				if 'config' in self.DER_config[RT]: #Check if an RT settings are provided
 					self.RT_config[RT] = self.DER_config[RT]['config'] 
 					LogUtil.logger.debug('{}:{} updated with {} from DER config file.'.format(self.name,RT,self.DER_config[RT]['config'] ))
+				elif 'config_id' in self.DER_config[RT]: #Check if an RT config id is provided
+					self.RT_config[RT] = config_dict[self.DER_config[RT]['config_id']]['config']
+					LogUtil.logger.debug('{}:{} updated with {} from config id {}.'.format(self.name,RT,config_dict[self.DER_config[RT]['config_id']]['config'],self.DER_config[RT]['config_id']))
+				
 			
 			for RT in ['LVRT','HVRT']:
 				for RT_level,RT_config in self.RT_config[RT].items():


### PR DESCRIPTION
* Fixes a bug that caused DER configs created from parent configurations to not use ride-through settings from parent and instead use the default ones. 
* Removes the use of derConfig for passing DER parameters. All parameters will need to be passed through either config file or as kwargs during instance creation.
* Add additional information in DER disconnect logging message.